### PR TITLE
Added file for plain CMFS

### DIFF
--- a/CMFS_20NG.ipynb
+++ b/CMFS_20NG.ipynb
@@ -27,7 +27,8 @@
     "from pprint import pprint\n",
     "from gensim.corpora import Dictionary\n",
     "import numpy as np\n",
-    "import operator"
+    "import operator\n",
+    "from sklearn.feature_selection import VarianceThreshold"
    ]
   },
   {
@@ -111,6 +112,20 @@
    ],
    "source": [
     "print \"Term-category matrix shape: {0}\".format(term_category_mat.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# New Matrix after applying Variance. \n",
+    "selector = VarianceThreshold()\n",
+    "selector.fit(term_category_mat)\n",
+    "selector.fit_transform(term_category_mat)"
    ]
   },
   {
@@ -243,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/Vanilla_CMFS_20NG.ipynb
+++ b/Vanilla_CMFS_20NG.ipynb
@@ -1,0 +1,394 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Implementation of Standard CMFS on 20NG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "Authors: Abhirav Gholba\n",
+    "         Bhargav Srinivasa\n",
+    "         Devashish Deshpande\n",
+    "         Gauri Kholkar\n",
+    "         Mrunmayee Nasery\n",
+    "\"\"\"\n",
+    "from sklearn.datasets import fetch_20newsgroups\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "from sklearn.feature_selection import SelectKBest, chi2\n",
+    "from sklearn.naive_bayes import MultinomialNB\n",
+    "from sklearn import metrics\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import operator\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "newsgroups_train = fetch_20newsgroups(subset='train', remove=('headers', 'footers', 'quotes'))\n",
+    "vec = CountVectorizer(stop_words='english')\n",
+    "document_term_mat = vec.fit_transform(newsgroups_train.data)\n",
+    "term_document_mat = document_term_mat.T\n",
+    "documents = len(newsgroups_train.filenames)\n",
+    "categories = len(newsgroups_train.target_names)\n",
+    "terms = term_document_mat.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No. of documents: 11314\n",
+      "No. of categories: 20\n",
+      "matrix.shape: (101323, 11314)\n",
+      "8\n",
+      "<class 'scipy.sparse.csc.csc_matrix'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"No. of documents: %d\\nNo. of categories: %d\" % (documents, categories)\n",
+    "print \"matrix.shape: {0}\".format(term_document_mat.shape)\n",
+    "print newsgroups_train.target[10]\n",
+    "print type(term_document_mat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Term-category feature-appearance matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "term_category_mat = np.zeros((terms, categories))\n",
+    "for doc in range(documents):\n",
+    "    cat = newsgroups_train.target[doc]\n",
+    "    for row in term_document_mat.getcol(doc).nonzero()[0]:\n",
+    "        term_category_mat[row][cat] += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Term-category matrix shape: (101323, 20)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"Term-category matrix shape: {0}\".format(term_category_mat.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Perform CMFS on term-category matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[  2.92719610e-08   7.28597222e-06   2.78309396e-06 ...,   5.88282467e-07\n",
+      "    2.72656836e-06   1.18472355e-07]\n",
+      " [  1.33768710e-06   2.15000369e-06   3.43217261e-07 ...,   5.26920017e-05\n",
+      "    1.01714536e-05   1.35350464e-06]\n",
+      " [  2.85130583e-07   2.77229556e-07   2.24044601e-07 ...,   9.16849120e-07\n",
+      "    2.65587955e-07   2.88502123e-07]\n",
+      " ..., \n",
+      " [  3.66596463e-07   3.56438001e-07   2.88057344e-07 ...,   2.94701503e-07\n",
+      "    3.41470227e-07   3.70931301e-07]\n",
+      " [  3.66596463e-07   3.56438001e-07   2.88057344e-07 ...,   2.94701503e-07\n",
+      "    3.41470227e-07   3.70931301e-07]\n",
+      " [  3.66596463e-07   3.56438001e-07   2.88057344e-07 ...,   2.94701503e-07\n",
+      "    3.41470227e-07   3.70931301e-07]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "term_freq_per_cat = np.cumsum(term_category_mat, axis=0)[-1, :]\n",
+    "for term in range(terms):\n",
+    "    # Frequency of the term across all categories\n",
+    "    # Standard CMFS\n",
+    "    total_term_freq = sum(term_category_mat[term, :])\n",
+    "    for cat in range(categories):\n",
+    "        numerator = float((term_category_mat[term][cat] + 1) ** 2)\n",
+    "        denominator = (total_term_freq + categories) * (term_freq_per_cat[cat] + terms)\n",
+    "        term_category_mat[term][cat] = numerator / denominator\n",
+    "        \n",
+    "# Final CMFS matrix\n",
+    "print term_category_mat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create term-cmfs dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Create term id (i.e. row no) - CMFS dict\n",
+    "term_cmfs_dict = {}\n",
+    "cmfs_max = np.max(term_category_mat, axis=1)\n",
+    "for i in range(terms):\n",
+    "    term_cmfs_dict[i] = cmfs_max[i]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract top 2000 features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Integer to term mapping dictionary\n",
+    "dictionary = vec.get_feature_names()\n",
+    "\n",
+    "sorted_feature_list = sorted(term_cmfs_dict.items(), key=operator.itemgetter(1), reverse=True)[:2000]\n",
+    "# print \"-------Selected features are-------\\n\"\n",
+    "# for term, cmfs in sorted_feature_list:\n",
+    "#     print \"Term: {0} \\t CMFS: {1}\".format(dictionary[term], cmfs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Naive bayes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(11314, 2000)\n"
+     ]
+    }
+   ],
+   "source": [
+    "feature_list = [term for term, _ in sorted_feature_list]\n",
+    "# Create matrix for only the selected features. Note that the features are being extracted\n",
+    "# on the original document-term matrix. This will help in mapping with the targets easily.\n",
+    "selected_feature_matrix = document_term_mat[:, feature_list]\n",
+    "print selected_feature_matrix.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "newsgroups_test = fetch_20newsgroups(subset='test', remove=('headers', 'footers', 'quotes'))\n",
+    "document_term_mat_test = vec.transform(newsgroups_test.data)\n",
+    "clf = MultinomialNB().fit(selected_feature_matrix, newsgroups_train.target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.592272968667\n"
+     ]
+    }
+   ],
+   "source": [
+    "pred = clf.predict(document_term_mat_test[:, feature_list])\n",
+    "print metrics.f1_score(newsgroups_test.target, pred, average='micro')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cmfs_scores = []\n",
+    "for i in range(200, 2001, 200):\n",
+    "    feature_list = [term for term, _ in sorted_feature_list[:i]]\n",
+    "    selected_feature_matrix = document_term_mat[:, feature_list]\n",
+    "    clf = MultinomialNB().fit(selected_feature_matrix, newsgroups_train.target)\n",
+    "    pred = clf.predict(document_term_mat_test[:, feature_list])\n",
+    "    f1_score = metrics.f1_score(newsgroups_test.target, pred, average='micro')\n",
+    "    cmfs_scores.append(f1_score * 100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test with chi2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ch2_scores = []\n",
+    "for i in range(200, 2001, 200):\n",
+    "    ch2 = SelectKBest(chi2, k=i)\n",
+    "    ch2_train = ch2.fit_transform(document_term_mat, newsgroups_train.target)\n",
+    "    ch2_test = ch2.transform(document_term_mat_test)\n",
+    "    clf = MultinomialNB().fit(ch2_train, newsgroups_train.target)\n",
+    "    pred = clf.predict(ch2_test)\n",
+    "    f1_score = metrics.f1_score(newsgroups_test.target, pred, average='micro')\n",
+    "    ch2_scores.append(f1_score * 100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot Accuracy vs Number of features graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEPCAYAAACp/QjLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xd8VFX+//HXJwQISOhFerWAwiqCiugSu2LF7iIsgq6I\nC7j4c9VdFdTv7oquYAUriih2WREVRSWiSBOp0qWGEnpCL8n5/XFvQsgkkJCZuZnk/Xw85jH33in3\nM0M4nznlnmPOOURERHKKCzoAEREpfpQcREQkhJKDiIiEUHIQEZEQSg4iIhJCyUFEREJEPDmYWVUz\n+9jMFprZAjM728wGmVmKmc3yb5dFOg4RESk4i/R1DmY2EvjBOTfCzOKB44B7gR3OuSERPbmIiByT\n+Ei+uZlVAc5zzv0ZwDl3EEgzMwCL5LlFROTYRbpZqSmwyczeNLNfzew1M6voP9bXzOaY2RtmVjXC\ncYiISCFEOjnEA22BYc65tsAu4EFgGF7iOA1YDzwT4ThERKQQItqsBKQAKc65Gf7+x8CDzrlNWU8w\ns9eBz3O/0Mw06ZOIyDFwzhW52T6iNQfn3AZgjZmd6B+6CPjNzI7P8bQuwLx8Xl+sbgMHDgw8BsVU\nsuJSTIop3LdwiXTNAaAv8K6ZlQN+B3oCz5vZaYADVgB3RSEOEREpoIgnB+fcHKB9rsPdI31eERE5\ndrpCuhCSkpKCDiGEYiq44hiXYioYxRR9Eb8I7liZmSuusYmIFFdmhgtDh3Q0+hzCyr+ATgpAyVVE\njlXMJQdQoVcQSqIiUhTqcxARkRBKDiIiEkLJQUREQig5iIhICCWHMBs9ejTt2rUjMTGRevXq0blz\nZyZPnsygQYOIi4vj+eefP+z5zz33HHFxcTz22GMAJCcnExcXR2JiYvbtmmuuAeC3337jkksuoUaN\nGlSrVo127drx1VdfRf0zikjJp+QQRkOGDOFvf/sbDz/8MBs3bmTNmjXcc889jB07FjPjxBNP5O23\n3z7sNSNHjuSkk046bHRR/fr12bFjR/bts88+A+Cqq67i0ksvJTU1lY0bN/L8889TuXLlqH5GESkd\nlBzCJC0tjYEDBzJs2DCuvfZaKlSoQJkyZbjiiisYPHgwAO3bt2f37t0sWLAA8GoC+/bto127dkcd\nnrt582ZWrlzJnXfeSXx8PGXLluWcc86hY8eOEf9sIlL6KDmEyZQpU9i7dy9dunQ54vO6deuWXXsY\nOXIk3bp1K9D716hRgxYtWtC1a1c+++wzUlNTixyziEh+SlxyMAvPrbC2bNlCzZo1iYvL+yvNqhnc\ndtttvPfeexw8eJAPPviA2267LeS569ato1q1atm3jz/+GDNj4sSJNGnShPvuu4969erRqVMnli1b\nVvhgRUSOIiavkD6SoC6erlGjBps3byYzMzPfBGFmNGzYkBYtWvDQQw9x4okn0qBBg+zHstSrV481\na9aEvL5+/fq88MILAKSkpPCXv/yF7t278/PPP0fgE4lIaVbiag5B6dChA+XLl2fMmDH5Pier9tC9\ne3eGDBlC9+7HPnN5gwYN6NOnD/Pnzz/m9xARyU+JqzkEpUqVKjz++OPcc889xMfHc/HFF1O2bFm+\n/fZbkpOTqVixYvZzb775Zho2bMg555wDUKAVnLZv387QoUPp3r07TZs2ZevWrYwYMYIOHTpE9HOJ\nSOmkmkMYDRgwgCFDhvB///d/1K5dm0aNGjFs2LDsTuqspqOEhAQuuOACEhISso/nbFbKa9K8cuXK\nsWrVKi666CKqVKlC69atqVChAm+99VbkP5iIlDoxt56DP1d5ABHFFn1PIqVTuNZzUM1BRERCKDmI\niEgIJQcREQmh5CAiIiGUHEREJISSg4iIhFByEBGREEoOIiISQskhwt566y3OO++8fB/v3Lkzo0aN\nimJEIiJHp+QQsC+//DJ7TYcvvviCc889l2rVqlG3bl3uvPNOdu7cGXCEIlIaRTw5mFlVM/vYzBaa\n2QIzO8vMqpvZBDNbYmbfmFnVSMcRC9LT03n00UdZv349CxcuZO3atdx///1BhyUipVDE51Yys5HA\nD865EWYWDxwH/BPY7Jx7ysweAKo55x7M9bqYm1tpzZo19O/fn59++onMzExuvfVW2rVrx+uvv87Z\nZ5/NG2+8QdWqVRk2bBiXXXYZAElJSXTr1o1evXqFvN+YMWMYOHAgc+fOLXQsxfl7kujauxc2b4ZN\nm7z7/Laz7p2DqlWhShXvPr/tvI5VqgT5LGciURKuuZUiOmW3mVUBznPO/RnAOXcQSDOzq4FO/tNG\nAsnAg3m+SYzIyMjgyiuv5KKLLuLdd98lLi6OX375haVLlzJt2jR69OjBli1beOWVV+jVqxdr164F\nQmdkzemHH37g1FNPjebHkGIuMxO2bcu7UM/v2P79ULOmd6tV6/D7U045tJ11i4uD7dshLc27z7md\nlgbr1uX/+J49kJh47MmlShUoWzbob1kg8us5NAU2mdmbwB+AmcC9QB3nXNYiyKlAnXCd0B4rcsIE\nwA0s3K/u6dOns379ep5++unsleA6duzI0qVLady4cXbNoHv37vTp04eNGzdSu3btfN9vwoQJvP32\n20yfPv3YP4QUe7t3F6yAz9rets0rfHMW6Fnb9epBmzaHH6tZ03t+YZe+Pf74Y/s8Bw9CevqRk8ua\nNTBvXv6Ply8fmjwaNoROnbxb/frHFpsUTqSTQzzQFvirc26GmT1LrhqCc86ZWdjaPwpbqIfLmjVr\naNy4cZ5LhB6f439a1qI/O3fuzDc5TJ06la5du/LJJ5/QokWLyAQsEeWcV0iuWePdUlJC71NSvMI0\n96/5rO3TTw/9tV+9OsQX4yW64uO9GKtXP7bXOwe7doUml2XL4OOPoW9fqFEDkpK8m5JF5ET6zywF\nSHHOzfD3PwYeAjaY2fHOuQ1mVhfYmNeLBw0alL2dlJREUlJSZKMtgoYNG7J69WoyMjIoU6bMMb/P\nrFmzuOaaa3jrrbc4//zzwxihhFNaWt4Ffs578H7xZt0aNICOHb37rP1j+VVfkpl5/RaVKnnfT079\n+3vNavPnQ3Ly4cmiU6dDCaO0JYvk5GSSk5PD/r7R6JCeBNzhnFtiZoOArPUytzjnBpvZg0DVWO+Q\nzszMpG3btlx88cU89thjxMXFMXPmTJYuXcobb7zBjz/+mP3cuLg4li1bRrNmzTj//PPp1q0bPXv2\nZP78+Vx44YW8+OKL3HjjjUWKp7h+T7Eg6xf/kQr/zMzDC/3c2w0aeM0iElmZmfDbb16ySE6GH36A\natUOJYrSmCxiokPa1xd418zKAb8DtwNlgA/NrBewErgpCnFEVFxcHJ9//jn9+vWjUaNGmBldu3bl\n9NNPD+lwzq8D+plnnmHLli307NmTnj17AtCkSRPmzZsX8fhLix07jl7wHzwYWtifdRbccMPhBb9+\n8QcvLg5at/Zuffseniw+/dSrbeRMFp06hdZIJG9aJrSEKu3f086dMHs2zJzp3WbPhlWr4MCBvH/l\n57yvWlUFf0mRmQkLFhxes6hS5fCaRUlLFuGqOSg5lFCl6XvauRNmzTqUCGbOhJUrvWGaZ5zh3U4/\nHZo1835FquAvvY6WLDp18n4gxDIlBzmikvo97dgRmghWrYJTTz2UCM44w0sM5coFHa0UdzmTxQ8/\nePdVqhzewR1EsnDO+1vfutUbvrx1a8G3d+1ScpAjKAnfU3p6aCJYsybvRKALpyQcMjNh4cJDNYvk\nZKhc+fBmqMIkiwMHCl+4b9vm3RISvJpu1tDggm5XqaLkIEcQa99Tejr8+uvhiSAlxbuo64wzoG1b\n775VKyUCiR7nQpuhEhO9JHH66d41GUcq6PfsOVR451eg5/VYtWrHXvNVs5IcUXH+ntLSQhPBunWH\nEkHWrWXL4n3Bl5Q+zh2qWcyd69UqjlTwB3Edi5KDHFFx+Z62bw9NBOvXwx/+cHgiOPlkJQKRcCjV\nyUEKJoh/2/Xr4d13YcYMLxGkpuadCIpwEbmIHEGpTQ5SPC1eDE8/7V14dOONcO65XiI46SQlApFo\niqUrpKUEmzYNBg+Gn36Ce+6BpUu9uW5EJLYpOUihOQfjx3tJYeVKuO8+GDUKjjsu6MhEJFyUHKTA\nDh6EDz6Ap57yEsQDD8BNN2loqUhJpOQgR7VrF4wYAc88A02awJNPwmWXaRoKkZJMyUHytWULvPgi\nvPSS18H8wQfe7KQiUvJpKXAJsWqVN9XxCSd401X8+KM3CkmJQaT0UHKQbHPnwm23eVNVJCR4K269\n/ro3HFVEShclh1LOOZg0CTp39voRWreG5cu9kUj16gUdnYgERX0OpVRmJowd6yWBLVvg/vu9pqOE\nhKAjE5HiQMmhlNm3D955x7uauXJlbzjqtdfqKmYROZySQymRng6vvALPPus1HQ0f7k07rOGoIpIX\nJYcSbsMGeO45eO01uOQS+OILOO20oKMSkeJOHdIl1NKlcNdd3uI4O3Z4s6SOHq3EICIFo+RQwvzy\nizcr6jnnQJ063mypL74ITZsGHZmIxBI1K5UAzsGECd7Io6VLYcAAePNNqFQp6MhEJNz2HdxH+r70\n7FvavrTD9sNFySGGHTwIH3/sTYS3fz/8/e9w662aCE+kONqfsd8rzPemHbFwT9ubRvr+XPs5Hs90\nmVRJqELl8pWzb1XKH9oPFy32E4PWrfOuXH7tNa+56O9/9y5ii1MjoUjEpe9LZ9HmRSzbuiy74M5Z\nwOdZ2O9LJ8NlhBTklctX9gr6cjm28yn0sx4rX6b8EVfE1GI/pYxzMHGiNwT1u+/g5pu9kUdt2gQd\nmUjJtHn3ZhZsWsDCTQu9+80LWbh5IVv3bOWkGidxQo0TqJZQLbvwrlupbkhBnrOQT4hPiKlljlVz\nKOa2b4eRI+HllyE+Hu6+25v/qHL4ao8ipZZzjnU71mUX/jnvD2QcoGWtlrSq2cq7r9WKljVb0rhq\nY+Ks+FbTtYZ0CTdzJgwb5k1pcfnl0KcPdOyoi9ZEjkVGZgar0lYdqgls9u4Xbl5IQnxCdsGfdd+y\nVkvqVqobU7/0syg5lEC7d3trJgwfDhs3Qu/e0LMn1K4ddGQisWF/xn6WbV12WFPQgk0LWLJlCTUr\n1jw8CdRqScuaLalRsWQteh4zycHMVgLpQAZwwDl3ppkNAu4ANvlPe8g5Nz7X60pNcliyxGs2evtt\nb82EPn28GVI135FI3nYf2M3izYtDmoJWbFtBoyqNDmsOalmzJSfXPJnE8olBhx0VsdQh7YAk59zW\nXMeGOOeGROH8xdLBg96sqMOHe+so9OzpXcWsi9VEPLv272LtjrWsTV/Liu0rspuBFmxawPqd62lR\nvUV2LeCmVjfRqlYrTqhxAgnxmlo4HKI1WimvLBZ7jXlhsG6dNwQ1axjq3XfD9ddD+fJBRyYSHZku\nk827N7M2fW124b92x1pS0lMO299zYA/1K9enfmJ9GldtTKuarbij7R20qtWKZtWaER+nwZaRFK2a\nw7dmlgG84px7zT/e18y6A78A9znntkchlkA4B99/79USvv8ebrkFvvrKmx1VpCTZd3Af63asyy7k\nswv8HIX+uh3rqFSuEg0qN6B+olf4169cnw4NOlC/cv3s49UrVI/JDuGSIhrJoaNzbr2Z1QImmNki\nYDjwuP/4E8AzQK/cLxw0aFD2dlJSEklJSREPNpy2bfOGoQ4f7tUM7r7bm9YisXQ0fUoJ4pxj+97t\nh37h5/OrP21vGnUT62YX+PUTvcK+fb322fv1EutRoWyFoD9SiZGcnExycnLY3zeqo5XMbCCw0zn3\nTI5jTYDPnXOtcz03Zjukf/nFG4Y6Zox35XKfPt5EePoRJMXVrv27WL5tOb9v+53Vaau9X/07Dk8C\nZcuUzS70c//qz0oCtY6rVayvASgNYqJD2swqAmWcczvM7DjgEuAxMzveObfBf1oXYF4k44iG3bvh\n/fe9WsLmzd502YsXaxiqFA/OOVJ3pfL71t+zk8Dv2/ztrb+Tti+NplWb0rx6cxpXaUz9xPqcUvuU\nQ0mgcn0qldNMjqVJRGsOZtYUGOPvxgPvOuf+Y2ZvA6fh9UesAO5yzqXmem1M1BwWL/aGoY4aBWef\n7dUSLr1Uw1Al+vZn7GfV9lVewZ9HEqhYtiLNqzWnWbVmNK/WnObVD23XTayrX/wlRMxc53CsinNy\nOHDg0DDUefOgVy/4y1+gSZOgI5OSbvve7YcX/Ft/Z/l279f/+p3rqZ9Yn+bVm+eZBMI5Y6cUX0oO\nAVi79tAw1ObNvQ7m667TMFQJn0yXSUp6SnZzT+5f//sz9uf7679RlUaULaP52ks7JYcoe/xxePZZ\nb72E3r01DFWOnXOONelrmJc6j6Vbl/L71kOF/8rtK6leoXq+v/5rVayl4Z1yRDHRIV1SfPSRNwR1\n8WKoVSvoaCSWpO9LZ/7G+cxNncu81HnM3ejdVyhbgda1W3NSjZNoXr05Fze/mObVmtO0WlMqlq0Y\ndNgiqjkczYIF0KkTfP01tG0bdDRSXB3MPMjSLUuZt3Gelwj8+427NnJKrVNoXbs1beq0oXWd1rSu\n3Zpax+lXhkSGmpWiIC0NzjwTHnoIevQINBQpRlJ3pjI3de5hSWDR5kXUS6znJQA/EbSp04Zm1ZpR\nJk5D1yR6lBwiLDPT62yuV8+7oE1Knz0H9vDbpt+85qAciSDDZRyWBFrXbs0ptU/RdQBSLKjPIcKe\nfBJSU+HDD4OORCIt02WycvvKw/oF5qbOZXXaak6scaJXC6jdhktbXEqbOm1idhEYkcJQzSEPX3/t\nTaE9fTrUrx9ICBIh2/Zsy64BZNUG5m+cT7WEaofXBup4ncUaGiqxRs1KEbJihXel80cfwR//GPXT\nS5hlukzGLxvPqzNfZeb6maTtTePU2qdm9wm0rt2aU2ufSrUK1YIOVSQslBwiYPdub53mHj2gf/+o\nnlrCbPeB3YyaM4qhU4dSsWxF+p3Vj06NOxX7xeFFikrJIcyc85LCwYPwzjuaQTVWrd+xnpdmvMSr\nM1+lQ8MO/O3sv9GpcSf1EUipoQ7pMBs+HGbNgilTlBhi0ewNsxk6dShjF4+la+uuTO45mRNqnBB0\nWCIx66g1BzO7GhjnnMuMTkjZ541azeHnn6FLF+++efOonFLCINNl8sWSLxg6dShLtiyh75l9ufOM\nO6leoXrQoYkEJmrNSmb2LtAB+BgY4ZxbVNSTFiiwKCWHDRugXTt49VVvYR4p/nbt38XIOSN5btpz\nJJZLZECHAdzY6kaNLBIhyn0OZlYFuBXogbcGw5vAe865HUUN4AjnjHhyOHAALrgALroIBg6M6Kkk\nDNamr+XF6S/y+qzXObfRuQw4ewDnNjpX/QkiOUS9Q9rMagLdgHuBBcAJwPPOueeLGkQ+54t4cujf\nH5Yvh88+gzgNYCm2fl3/K0OmDOHLpV9yW5vb6HdWP1pUbxF0WCLFUtQ6pM3sGrwawwnA20B759xG\nfwnQBUBEkkOkvfMOfPklzJihxFAcZWRmMG7JOIZMHcLybcvpd2Y/Xrj8BV2PIBIlBRmtdB0w1Dk3\nKedB59xuM7sjMmFF1pw58Le/wfffQ9WqQUcjOe3cv5O3Zr/Fs1OfpXqF6gzoMIDrW16v/gSRKCtI\nh3QzYL1zbo+/XwGo45xbGdHAItSstHUrtG8P//oX3HJL2N9ejlFKegovTHuBN2a9QacmnRhw9gDO\naXiO+hNECilczUoFaVD5EMjIsZ+JN3Ip5mRkQNeucM01SgzFxYy1M/jTJ3+izfA27MvYx/Q7p/PJ\nTZ/QsVFHJQaRABWkWSneObc/a8c5t8/MYrKO/9hjsGcPDB4cdCSlW0ZmBmMXj2XI1CGsTltNvzP7\nMfyK4VRJqBJ0aCLiK0hy2Gxm1zjnPoPsDurNkQ0r/D7/3Fvq85dfoGxMprbYt2PfDt6c/SbPTXuO\nWhVrMaDDAK5reR3xcbpQX6S4KUifQwvgXaCefygF6OacWxbRwMLY57B0qTeh3tix3oyrEl2r01bz\nwrQXGDF7BBc0vYABZw+gQ8MOQYclUiJFbSirnwTOMrNEb9ftLOpJo2nnTm9qjCeeUGKItmkp0xg6\ndSjf/P4NPU7rwcy/zKRJ1SZBhyUiBVDQK6SvBFoBCVnHnHOPRzCusNQcnINbb4WKFeGNNzShXjRk\nZGbwv0X/Y8jUIaxNX0v/s/rTq20vKpevHHRoIqVCNC+CewWoAFwAvAbcCEwr6omjYehQWLYMfvxR\niSHSMl0mnyz4hEE/DKJSuUrcf879XHvytepPEIlRBelzmOeca21mc51zbcysEjDeOXduRAMrYs0h\nOdkbrjptGjRuHL645HDOOT5b/BkDkwdSrkw5Hk96nMtaXKZhqCIBieZ6Dnv8+91mVh/YAhxf1BNH\nUkqK15z0zjtKDJHinOPLpV/yaPKjZGRm8MT5T3DViVcpKYiUEAVJDp+bWTXgaWCmf+y1gp7AzFYC\n6XgX0h1wzp1pZtWBD4DGwErgJufc9kLEna99++D66+Hee73ZViW8nHNMWD6BRyc+ys79O3ks6TG6\ntOyipTdFSpgjNiuZWRzQwTk32d9PABIKU5Cb2QrgDOfc1hzHngI2O+eeMrMHgGrOuQdzve6YmpXu\nugu2bIGPPlI/Q7hNXDGRR5MfZdOuTQxKGsSNrW6kTFyZoMMSkRyi0qzknMs0s5eA0/z9vcDeYzhP\n7kCvBjr52yOBZOBBiuiNN2DSJJg+XYkhnCavnswjEx9hddpqBnYayK2tb1VHs0gJV5AO6f8CU4FP\njuWnvJktB9LwmpVecc69ZmbbnHPV/McN2Jq1n+N1hTrdjBlwxRVecjj55MJGKXmZljKNR5MfZcmW\nJTzyx0fo1qabZkcVKeai2SHdGxgAZJhZVq3BOecKOnC9o3NuvZnVAiaY2WHLjDrnnJnlmQUGDRqU\nvZ2UlERSUlKeJ9i0CW64AV55RYkhHH5d/yuPTnyUOalzePi8h7n99NspV6Zc0GGJSB6Sk5NJTk4O\n+/sWeCW4sJzMbCCwE7gTSHLObTCzusBE59zJuZ5boJrDwYNw2WVw5pnw739HJOxSY27qXAYmD2T6\n2uk8dO5D3NH2DhLiE47+QhEpNqJ5Edwf8zqee/GffF5bESjjnNthZscBlwCPAWOBPwOD/fv/FSbo\nnP75T28ltyeeONZ3kAWbFjAoeRCTVk3igY4PMPq60VQoWyHosEQkQAVpVvo7kPUTPgE4E29I6wUF\neG0dYIw/9j0eeNc5942Z/QJ8aGa98IeyFjJuwBuR9OGHXn9DGQ2aKbQlW5bw+A+PM2H5BO7rcB9v\nXvMmx5U7LuiwRKQYKHSzkpk1BJ5zzl0XmZCyz3PEZqUFC6BTJ/j6a2jbNpKRlDzLty3niUlPMG7J\nOO496176ndWPxPKJQYclImEQzQ7p3FKAlkU9cVGkpXkzrT79tBJDYazavop//fgvPl34KX89868s\n7buUqglaRFtEQhWkz+GFHLtxeNc8zMzn6RGXmQl//jNceCH06BFUFLFlbfpa/v3jv3n/t/fpfUZv\nlvRdQvUK1YMOS0SKsYLUHGZyqM/hIDA664rpIDz5JKSmen0NcmQbdm7gyZ+eZNTcUfQ6vReL7llE\nreNqBR2WiMSAgiSHj4E9zrkMADMrY2YVnXO7IxtaqG++gZde8q6ALqdh9/natGsTT01+ihGzR9C9\nTXd+6/Mbx1cq1nMlikgxU5DZ0r7FW88hS0X/WFStWAHdusF770H9+tE+e2zYsnsL//juH5z80sns\nObiHub3nMvSyoUoMIlJoBak5JORcGtS/ZqFiBGMKsWcPXHcd/OMf8Mc8r7oo3bbv3c7QKUN5acZL\nXN/yembdNYtGVRoFHZaIxLCCJIddZnaGc24mgJm149AaDxHnHPTuDa1aQb9+0TprbNi5fyfPTn2W\n56Y9x1UnXsX0O6fTrFqzoMMSkRKgIMnhXrwL1tb7+3WBmyMX0uGGD4dZs2DKFM20mtNniz6j3/h+\ndGzYkZ97/swJNU4IOiQRKUEKdBGcmZUDTvJ3Fzvn9kc0Ku+cbvJkR5cu8PPP0Lx5pM8YG1ZtX0W/\n8f1YvHkxL1/5MklNkoIOSUSKkXBdBHfUDmkz+ytwnHNunnNuHnCcmfUp6okL4qab4M03lRgADmQc\n4L8//5czXj2D9vXaM6f3HCUGEYmYgjQr3emcezFrxzm3zcz+AgyLXFj+ie+Ezp0jfZbi7+c1P9N7\nXG/qJtZl6h1TaVG9RdAhiUgJV5DFfuYBf3DOZfr7ZYC5zrlTIhqYmcvIcMSV4qWJt+7ZykPfPsS4\npeMYcskQbjrlJkwdLyJyBFFrVgK+Bt43swvN7CLgfWB8UU9cEKU1MTjnGDVnFKcMO4VyZcqxoM8C\nbj71ZiUGEYmagjQrPQD8BbgbbxqNuXgjliQCFm9ezN1f3M32vdsZe8tY2tdvH3RIIlIKHfW3uT9t\nxjS8dRfOBC4EFkY2rNJn78G9DJw4kI4jOnLNSdcw/c7pSgwiEph8aw5mdhJwK941DZuAj/D6KJKi\nE1rpMeH3CfT5sg9/qPMH5vSeQ/3Kmh9ERIKVb4e0mWUC44C/OudW+8dWOOeaRiWwAq4hHcs27NzA\ngK8HMCVlCi9e/iJXnHhF0CGJSIyLRof0dXjTZEwys5fN7EJAPaJhkJGZwbAZw2g9vDWNqzTmtz6/\nKTGISLFSkKGslYBr8JqYzgfeBsY4576JaGAltOYwa/0sen/Rm3JlyvHyFS9zSu2IjggWkVImXDWH\nQq0hbWbVgRuAW5xzFxT15Ec5V4lKDjv27eDRiY8yev5o/nPhf+hxWg/irJSO1RWRiAkkOURTSUkO\nzjnGLBpD//H9uajZRTx98dPUrFgz6LBEpIQKV3IoyHUOcoxWbl9J36/68vvW33mnyzt0atIp6JBE\nRApE7RoRcCDjAIN/Gky7V9vRoUEHZveercQgIjFFNYcw+2n1T/Qe15uGVRpq8R0RiVlKDmGyZfcW\nHvj2AcYvG8/QS4dyQ6sbNBeSiMQsNSsVkXOOkbNHcsqwU6hYtiIL7lnAjafcqMQgIjFNNYciWLhp\nIXd/cTdPpS90AAAPuklEQVQ79+9k3J/G0a5eu6BDEhEJC9UcjsGeA3t4+PuHOe/N87i+5fVMu2Oa\nEoOIlCgRTw5mVsbMZpnZ5/7+IDNL8Y/NMrPLIh1DOH297GtOHX4qS7YsYe7dc+l7Vl/KxJUJOiwR\nkbCKRrNSf2ABkOjvO2CIc25IFM4dNht2bqD/+P7MWDuDlzq/xOUnXB50SCIiERPRmoOZNQA6A69z\naNI+I8Ym8Nu2ZxvnjzyfRpUbMb/PfCUGESnxIt2sNBS4H8jMccwBfc1sjpm9YWZVIxxDkew7uI8u\nH3Shc4vOPH3J01QsWzHokEREIi5izUpmdiWw0Tk3y8yScjw0HHjc334CeAboldd7DBo0KHs7KSmJ\npKSkvJ4WMc45eo7tSc2KNXn6kqejem4RkYJITk4mOTk57O8bsYn3zOzfQDfgIJAAVAY+cc51z/Gc\nJsDnzrnWebw+8In3Hv7+Yb5b8R3fd/+eCmUrBBqLiEhBRGOxnyJxzv3DOdfQXznuFuB751x3M6ub\n42ldgHmRiqEoXv/1dd6f/z5jbxmrxCAipU60LoIzvL4GgKfM7A/+/grgrijFUGDf/P4ND3//MJNu\nn0St42oFHY6ISNRpPYdc5myYw8WjLubTmz/l3EbnRv38IiJFUeyblWJRSnoKV753JS9c/oISg4iU\nakoOvvR96Vwx+gr+2v6v3HzqzUGHIyISKDUr4S3Oc9V7V9GkahOGXzFcM6qKSMxSs1KYOOfo80Uf\n4iyOFzu/qMQgIoKm7ObJn55k5vqZ/NDjB+LjSv3XISIClPLkMHreaF6e+TJTek0hsXzi0V8gIlJK\nlNrkMGnVJO4dfy/fdf+Oeon1gg5HRKRYKZV9Dos2L+LGj25k9PWjaV0nZOYOEZFSr9Qlh9SdqXR+\ntzODLxrMRc0uCjocEZFiqVQlh90HdnP1+1fTrU03epzWI+hwRESKrVJznUNGZgY3fHQDieUSGXnt\nSA1ZFZESKVzXOZSaDun7vrmPtL1pfHDDB0oMIiJHUSqSw3NTn2PC8glM7jmZcmXKBR2OiEixV+KT\nw/8W/Y+nfn6KyT0nUzWhWK9IKiJSbJTo5DB97XTu/PxOvur6FU2qNgk6HBGRmFFiRyst37aca9+/\nlhFXj6BdvXZBhyMiElNKZHLYumcrnd/tzD/P+ydXnXRV0OGIiMScEjeUdd/BfVzyziW0r9ee/17y\n3whEJiJSfIVrKGuJSg6ZLpPbPr2N/Rn7+fDGD4mzElkxEhHJl65zyMMj3z/Cyu0r+a77d0oMIiJF\nUGKSw2szX+OD3z5gSq8pVChbIehwRERiWolIDl8v+5pHJj7CpNsnUeu4WkGHIyIS82I+OczZMIdu\nY7ox5uYxnFjjxKDDEREpEWK6YT4lPYUr37uSFzu/SMdGHYMOR0SkxIjZ5JC+L50rRl9B3zP7ctMp\nNwUdjohIiRKTQ1kPZBzgyveupFnVZgy7YphmWRUR8YVrKGvM1Rycc/T5og/xcfG80PkFJQYRkQiI\nuQ7p//z0H2aun8mk2ycRHxdz4YuIxISI1xzMrIyZzTKzz/396mY2wcyWmNk3ZlbgebRHzxvNqzNf\nZdyfxlGpXKXIBS0iUspFo1mpP7AAyOpAeBCY4Jw7EfjO3z+qH1b+wL3j72Xcn8ZRL7FeZCIVEREg\nwsnBzBoAnYHXgazOgauBkf72SODao73Pos2LuOnjm3jv+vc4tfapEYlVREQOiXTNYShwP5CZ41gd\n51yqv50K1DnSG6TuTKXzu50ZfNFgLmx2YYTCFBGRnCKWHMzsSmCjc24Wh2oNh/HHquY7lnb3gd1c\n9d5VdGvTjR6n9YhMoCIiEiKSw33OAa42s85AAlDZzEYBqWZ2vHNug5nVBTbm9wZtb21L+fjykALJ\nlkxSUlIEwxURiT3JyckkJyeH/X2jchGcmXUC/p9z7iozewrY4pwbbGYPAlWdcyGd0mbmzn/rfMbf\nNp5yZcpFPEYRkZIgphb78ZPDfc65q82sOvAh0AhYCdzknNuex2vctj3bqJpQ4JGuIiKlXkwlh2Nx\nrMuEioiUZqV2+gwREYk8JQcREQmh5CAiIiGUHEREJISSg4iIhFByEBGREEoOIiISQslBRERCKDmI\niEgIJQcREQmh5CAiIiGUHEREJISSg4iIhFByEBGREEoOIiISQslBRERCKDmIiEgIJQcREQmh5CAi\nIiGUHEREJISSg4iIhFByEBGREEoOIiISQslBRERCKDmIiEgIJQcREQmh5CAiIiGUHEREJEREk4OZ\nJZjZNDObbWYLzOw//vFBZpZiZrP822WRjENERAonosnBObcXON85dxrQBjjfzM4FHDDEOXe6fxsf\nyTjCJTk5OegQQiimgiuOcSmmglFM0RfxZiXn3G5/sxxQBtjm71ukzx1uxfGPQTEVXHGMSzEVjGKK\nvognBzOLM7PZQCow0Tn3m/9QXzObY2ZvmFnVSMchIiIFF42aQ6bfrNQA+KOZJQHDgabAacB64JlI\nxyEiIgVnzrnonczsEWCPc+6/OY41AT53zrXO9dzoBSYiUoI454rcbB8fjkDyY2Y1gYPOue1mVgG4\nGHjMzI53zm3wn9YFmJf7teH4cCIicmwimhyAusBIM4vDa8Ia5Zz7zszeNrPT8EYtrQDuinAcIiJS\nCFFtVhIRkdgQyBXSZtbQzCaa2W9mNt/M+vnHq5vZBDNbYmbf5BzFZGYPmdlSM1tkZpdEMLYy/oV5\nnxeHmMysqpl9bGYL/QsJzyoGMT3k/9vNM7PRZlY+iJjMbISZpZrZvBzHCh2HmZ3hf5alZvZcBGJ6\n2v/3m2Nmn5pZlaBjyvHYfWaWaWbVi0NMZtbX/67mm9ngaMaUX1xmdqaZTffLhRlm1j6acVkYy8tC\nxeWci/oNOB44zd+uBCwGWgJPAX/3jz8APOlvtwJmA2WBJsAyIC5CsQ0A3gXG+vuBxgSMBHr62/FA\nlSBj8t93OVDe3/8A+HMQMQHnAacD83IcK0wcWTXn6cCZ/vaXwGVhjunirM8MPFkcYvKPNwTG4zXt\nVg86JuB8YAJQ1t+vFc2YjhBXMnCpv3053pD8aH5X4SgvCx1XIDUH59wG59xsf3snsBCoD1yNVxji\n31/rb18DvOecO+CcW4n3Yc8Md1xm1gDoDLzOoYv0AovJ/4V5nnNuBIBz7qBzLi3ImIB04ABQ0czi\ngYrAuiBics79yKGLKrMUJo6zzKwukOicm+4/7+0crwlLTM65Cc65TH93Gt6w7kBj8g0B/p7rWJAx\n3Q38xzl3wH/OpmjGdIS41uP9KAOoCqyNZlxhKi8LHVfgE++ZN5T1dLz/NHWcc6n+Q6lAHX+7HpCS\n42UpeF9OuA0F7gcycxwLMqamwCYze9PMfjWz18zsuCBjcs5txbsuZTVeUtjunJsQZEy5FDaO3MfX\nRji+nni/2AKNycyuAVKcc3NzPRTk93QC3rVQU80s2czaFYOYAB4EnjGz1cDTwENBxVXE8rJQcQWa\nHMysEvAJ0N85tyPnY86r9xyptzysPelmdiWw0Tk3i3ym9oh2THjNSG2BYc65tsAuvD/UwGIys+bA\nvXjV1XpAJTO7LciY8j3J0eOIKjP7J7DfOTc64DgqAv8ABuY8HFA4OcUD1ZxzZ+P9SPsw4HiyvAH0\nc841Av4GjAgiiCKWl4UWWHIws7J4H3SUc+5//uFUMzvef7wusNE/vhavfTRLAw5V7cLlHOBqM1sB\nvAdcYGajAo4pBe/X3Qx//2O8ZLEhwJjaAT8757Y45w4CnwIdAo4pp8L8e6X4xxvkOh72+MysB16T\nZdcch4OKqTlecp/j/703AGaaWZ0AY8I/z6cA/t98pnnXSgX6b4fXRj/G3/6YQ82iUYsrDOVl4eMq\nSudNETpYDK+9a2iu408BD/jbDxLawVIOr6nld/wOlgjF1wnvqu3AYwImASf624P8eAKLCfgDMB+o\n4P87jgTuCSomvEIud4d0oeLAq6Kf5X+ecHRq5o7pMuA3oGau5wUWU67H8uqQDuJ7ugt4zN8+EVgd\n7ZjyietXoJO/fSEwI5pxEcbysjBxha3QKOSHPRevXX82MMu/XQZUB74FlgDfAFVzvOYfeB0ri/BH\nDkQwvk4cGq0UaEx4hfEMYA7er6oqxSCmv+MVdvPwkkPZIGLCq+GtA/YDa4DbjyUO4Az/sywDng9z\nTD2BpcCqHH/rwwKKaV/W95Tr8eX4ySHImPy/o1H+OWYCSdGM6Qh/U+3wCtXZwBTg9Ch/V2ErLwsT\nly6CExGREIGPVhIRkeJHyUFEREIoOYiISAglBxERCaHkICIiIZQcREQkhJKDxAx/aumcS8z+PzMb\neKTXFPB9y5nZt/6UzDfmeuxkM5ttZjPNrNkxvPe95q2CKBJTlBwkluwHuphZDX8/XBfptMWbnuZ0\n59xHuR67FvjIOXeGc275Mbx3f7yZawvMzMocw3lEwkrJQWLJAeBVvMnPDmNmTczse/MW1PnWzBrm\n8ZzqZvY//zlTzKy1mdUC3gHa+zWHZjme3xmvcL/bzL7zj91mZtP8575s3hK4mNkwfyGY+WY2yD/W\nD29ywok5Xr8zx/vfYGZv+ttv+e83FRhsZs3N7Csz+8XMJpnZSf7zbvQXa5ltZj+E40sVyVNRLzfX\nTbdo3YAdQCLeXECVgfuAgf5jnwPd/O3bgTF5vP4F4BF/+3xglr+dPZdWHq8ZCAzwt1sCY4Ey/v6w\nHOes5t+XASYCp/r72fMWZX2GHNvXA2/622/57501a8F3QAt/+yzgO397LlDX364c9L+JbiX3Fh+O\nBCMSLc65HWb2NtAP2JPjobM5tHDJO3iTkuXWEbjOf5+JZlbDnwb5aNNVZz1+Id7cNL+YGXiTD27w\nH7vZzO7Em3a6Lt7kZ/ML89Hwmq+cH1MH4CP/POBNogYwGRhpZh/iz2AqEglKDhKLnsWbKfPNXMcL\nsiZBUdctGOmc+8dhb2jWFK8W0845l+Y3FSXk8/qc/SS5O6p3+/dxeIsonR7yYufuNrMzgSvwptk+\nw3kLMImElfocJOY457bhLQTTi0OF7c/ALf52V7ypznP70X8MM0sCNjlv2cWC+g64we+nyOrDaITX\n1LULSPfXRLg8x2t24DWBZUn1R0DFAV3Io1PdOZcOrDCzG/zzmJm18bebO+emO+cGAps4fH5+kbBR\ncpBYkrMgfQaomWO/L3C7mc3BSwD983j9IOAM/zn/Bv6c432PunKdc24h8DDwjf8e3wDHO2+pzVl4\n0yO/C/yU47WvAuOzOqTx5t0fh9c8tO4In68r0MvMZuM1T13tH3/KzOaa2Txgsgtd5lMkLDRlt4iI\nhFDNQUREQig5iIhICCUHEREJoeQgIiIhlBxERCSEkoOIiIRQchARkRBKDiIiEuL/A9vzkiheYIXV\nAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fcad814fdd0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = [i for i in range(200, 2001, 200)]\n",
+    "plt.plot(x, cmfs_scores, x, ch2_scores)\n",
+    "plt.xlabel(\"No of features\")\n",
+    "plt.ylabel(\"Accuracy\")\n",
+    "plt.legend((\"CMFS\", \"chi2\"), loc='best')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
@dsquareindia , I thought it would be useful to have a separate notebook for the normal CMFS algo (i.e, described in the original paper). I rewrote parts of the code and made the Naive Bayes run on the features selected by the original CMFS and plotted it against chi2. Results are a little behing iCMFS. 

I think you can merge, I didn't mess with the old file and added a separate notebook.
